### PR TITLE
Fixed node ReferenceError: window is not defined

### DIFF
--- a/isbn.js
+++ b/isbn.js
@@ -224,6 +224,6 @@ ISBN.isbn.prototype = {
   }
 };
   
-  var exports = window === void 0 ? module.exports : window;
+  var exports = typeof window === 'object' && window ? window: module.exports;
   exports.ISBN = ISBN;
 }());


### PR DESCRIPTION
Getting an error with the current build:

```
  var exports = window === void 0 ? module.exports : window;
                ^
ReferenceError: window is not defined
    at /path/to/project/node_modules/isbn/isbn.js:227:17
```

This patch fixes the error and makes `isbn` run fine in node.
