### PR TITLE
Change import/export business, and use groups from isbn-groups in module

### DIFF
--- a/isbn-groups.js
+++ b/isbn-groups.js
@@ -889,4 +889,6 @@ ISBN.GROUPS = {
     "ranges": [["0", "1"], ["20", "59"], ["600", "799"]]
   }
 };
+// var exports = typeof window === 'object' && window ? window: module.exports;
+module.exports.ISBN = ISBN;
 }());

--- a/isbn.js
+++ b/isbn.js
@@ -1,6 +1,8 @@
 (function () {
   "use strict";
 
+
+
 var ISBN = {
   VERSION: '0.01',
   GROUPS: {
@@ -223,7 +225,11 @@ ISBN.isbn.prototype = {
     return null;
   }
 };
-  
-  var exports = typeof window === 'object' && window ? window: module.exports;
-  exports.ISBN = ISBN;
+
+var G = require('./isbn-groups')
+Object.assign(ISBN, G.ISBN)
+
+//   var exports = typeof window === 'object' && window ? window: module.exports;
+  module.exports = {ISBN};
 }());
+


### PR DESCRIPTION
Please consider updating the module on npm so it includes all the generated "isbn groups".

As is, it cannot parse isbns from e.g. Denmark.
This PR is my own "fix", which works by importing `isbn-groups` into `isbn`. It works with Webpack, but will probably  stop the module from working in other use cases. 

